### PR TITLE
Added setter/getter support

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -9,7 +9,8 @@ module.exports = function(Parent, ...mixins) {
   for (let mixin of mixins) {
     for (let prop in mixin) {
       debug('mixin %s', prop);
-      Mixed.prototype[prop] = mixin[prop];
+      var descriptor = Object.getOwnPropertyDescriptor(mixin, prop);
+      Object.defineProperty(Mixed.prototype, prop, descriptor)
     }
   }
   return Mixed;

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,8 @@ let Droppable = {
   drop() { return 'droppable'; }
 };
 
-let MyDraggable = Object.create(Draggable)
+let MyDraggable = Object.create({});
+Object.assign(MyDraggable, Draggable);
 MyDraggable.dragAndLog = function() {
   console.log("Dragged");
   return this.drag();


### PR DESCRIPTION
It's much better to directly set the descriptors on the prototype :).

It is a shame that you have to squash the original constructor.name ;(.
